### PR TITLE
Link for Dockerizing ROS 2 Projects is broken

### DIFF
--- a/2025/content/docs/tutorial-1.mdx
+++ b/2025/content/docs/tutorial-1.mdx
@@ -21,7 +21,7 @@ Welcome to your first F1TENTH tutorial! This version includes embedded good codi
 ## 1. Building and Running Inside Docker
 
 ### Sample Dockerfile
-
+```
 Dockerfile
 FROM ros:humble
 RUN apt update && apt install -y python3-colcon-common-extensions
@@ -29,10 +29,11 @@ WORKDIR /ros2_ws
 COPY . /ros2_ws
 RUN . /opt/ros/humble/setup.sh && colcon build
 CMD ["bash"]
+```
 
 Containerizing ROS 2 Projects
 
-> 📘 Learn more: [Dockerizing ROS 2 Projects](https://docs.ros.org/en/rolling/How-To-Guides/Docker.html)
+> 📘 Learn more: [Dockerizing ROS 2 Projects](https://docs.ros.org/en/rolling/How-To-Guides.html)
 
 ---
 


### PR DESCRIPTION
# Description

Fixed the code block formatting for sample Dockerfile given in ROS Tutorial 1 and also fixed the broken link that followed it

Fixes # (issue)

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x ] Any dependent changes have been merged and published in downstream modules

